### PR TITLE
- added created at property to the prompt request

### DIFF
--- a/Ollama_Component/Mappers/DbMappers/HistoryMapper.cs
+++ b/Ollama_Component/Mappers/DbMappers/HistoryMapper.cs
@@ -43,6 +43,8 @@ public static class HistoryMapper
         Prompt prompt = new()
         {
             Content = request.Content,
+            CreatedAt = request.CreatedAt,
+
         };
 
         if(request.Options != null)

--- a/Ollama_Component/Services/ChatService/Models/PromptRequest.cs
+++ b/Ollama_Component/Services/ChatService/Models/PromptRequest.cs
@@ -31,6 +31,8 @@ namespace Ollama_Component.Services.ChatService.Models
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonPropertyName("Options")]
         public Options? Options { get; set; }
+
+        public DateTime CreatedAt { get; set; } = DateTime.Now;
     }
 
     public class Options


### PR DESCRIPTION
-  history mappers now mapes the "createdat" to the prompt DB model
fixed the sorting datetime of the get messages 